### PR TITLE
feat(tprintf): Add `tprintf.c` example

### DIFF
--- a/src/section-3/tprintf/tprintf.c
+++ b/src/section-3/tprintf/tprintf.c
@@ -1,0 +1,15 @@
+// Prints int and float values in various formats.
+
+#include <stdio.h>
+int main(void) {
+  int i;
+  float x;
+
+  i = 40;
+  x = 839.21f;
+
+  printf("|%d|%5d|%-5d|%5.3d|\n", i, i, i, i);
+  printf("|%10.3f|%10.3e|%-10g|\n", x, x, x);
+
+  return 0;
+}


### PR DESCRIPTION
This example mainly showcases the different conversion specifications for integer and float values.

The other conversion specifications (e.g. for characters) are not shown for now.