### PR TITLE
feat(sum2): Add `sum2.c` example

### DIFF
--- a/src/section-7/sum2/sum2.c
+++ b/src/section-7/sum2/sum2.c
@@ -1,0 +1,19 @@
+// Sums a series of integers (using long variables).
+
+#include <stdio.h>
+
+int main(void) {
+  long n, sum = 0;
+  printf("enter integers (0 to terminate): ");
+
+  scanf("%ld", &n); // read input as long (notice the "l" conversion specifier).
+
+  while (n != 0) {
+    sum += n;
+    scanf("%ld", &n);
+  }
+
+  printf("The sum is: %ld\n", sum);
+
+  return 0;
+}


### PR DESCRIPTION
This example demonstrates a potential integer overflow scenario, and solution to fix the overflow by using `long` instead of `int` and read accordingly by using the proper conversion specification (`l`).