### PR TITLE
feat(pun2): Add `pun2.c` example

### DIFF
--- a/src/section-9/pun2/pun2.c
+++ b/src/section-9/pun2/pun2.c
@@ -1,0 +1,10 @@
+// Prints a bad pun.
+
+#include <stdio.h>
+
+void print_pun(void) { printf("To C, or not to C, that is the question.\n"); }
+
+int main(void) {
+  print_pun();
+  return 0;
+}


### PR DESCRIPTION
This example showcases functions that do not need any arguments.

To indicate that a function needs no arguments, we can use the `void` keyword in the argument list similar to how it's used for functions that do not return anything.