### PR TITLE
feat(remind2): Add `remind2.c` example

### DIFF
--- a/src/ch-17/remind2/Makefile
+++ b/src/ch-17/remind2/Makefile
@@ -1,0 +1,2 @@
+remind2: remind2.c
+	gcc -o ./remind2 -g3 -Wall -Wextra ./remind2.c

--- a/src/ch-17/remind2/remind2.c
+++ b/src/ch-17/remind2/remind2.c
@@ -1,0 +1,78 @@
+// Prints a one-month reminder list (dynamic string version).
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_REMIND 60
+#define MSG_LEN 60
+
+int read_line(char str[], int n);
+
+int main(void) {
+  char *reminders[MAX_REMIND];
+  char day_str[3], msg_str[MSG_LEN + 1];
+  int day, i, j, num_remind = 0;
+
+  for (;;) {
+    if (num_remind == MAX_REMIND) {
+      printf("-- No space left --\n");
+      break;
+    }
+
+    printf("Enter day and reminder: ");
+    scanf("%2d", &day);
+    if (day == 0) {
+      break;
+    }
+    sprintf(day_str, "%2d", day);
+    read_line(msg_str, MSG_LEN);
+
+    for (i = 0; i < num_remind; i++) {
+      if (strcmp(day_str, reminders[i]) < 0) {
+        break;
+      }
+    }
+
+    for (j = num_remind; j > i; j--) {
+      reminders[j] = reminders[j - 1];
+    }
+
+    // // NOTE: Main gist of the example.
+    // At this point, `reminders` is an array
+    // of null pointers.
+    // Therefore, we need to allocate just enough memory
+    // for each reminder and make these null pointers point
+    // to allocated memory blocks.
+    // Only then we can safely write through those pointers.
+    reminders[i] = malloc(2 + strlen(msg_str) + 1);
+    if (reminders[i] == NULL) {
+      printf("-- No space left --\n");
+      break;
+    }
+
+    strcpy(reminders[i], day_str);
+    strcat(reminders[i], msg_str);
+    num_remind++;
+  }
+
+  printf("\nDay Reminder\n");
+  for (i = 0; i < num_remind; i++) {
+    printf(" %s\n", reminders[i]);
+  }
+
+  return 0;
+}
+
+int read_line(char str[], int n) {
+  int ch, i = 0;
+
+  while ((ch = getchar()) != '\n') {
+    if (i < n) {
+      str[i++] = ch;
+    }
+  }
+  str[i] = '\0';
+
+  return i;
+}


### PR DESCRIPTION
This example showcases how dynamic memory allocation can be utilized by using the previous `remind.c` example.

In the first version, we used a two-dimensional array to store all the reminders.
The memory for all reminders in the `reminders` array were allocated by the compiler in a fixed way.

In this version, we use a one-dimensional array to store the reminders. The elements are basically null pointers.

Instead of allocating a fixed memory beforehand, we dynamically allocate just enough memory for a single reminder as we insert it.