### PR TITLE
feat(stack): Add `stack` example

### DIFF
--- a/src/ch-19/stack/stack.h
+++ b/src/ch-19/stack/stack.h
@@ -1,0 +1,11 @@
+#ifndef STACK_H
+#define STACK_H
+
+#include <stdbool.h>
+
+void make_empty(void);
+bool is_empty(void);
+bool is_full(void);
+void push(int i);
+int pop(void);
+#endif

--- a/src/ch-19/stack/stack1.c
+++ b/src/ch-19/stack/stack1.c
@@ -1,0 +1,45 @@
+// The implentation of `stack.h` by using an array.
+
+#include "stack.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define STACK_SIZE 100
+
+// NOTE:
+// Using `static` keyword prevents these
+// variables to be used by other modules.
+static int contents[STACK_SIZE];
+static int top = 0;
+
+// NOTE:
+// Similar to `private` functions in other languages,
+// using `static` on a function limits its usage to the
+// functions defined on the same file only.
+// Simply put, this function is not part of the interface.
+static void terminate(const char *message) {
+  printf("%s\n", message);
+  exit(EXIT_FAILURE);
+}
+
+void make_empty(void) { top = 0; }
+
+bool is_empty(void) { return top == 0; }
+
+bool is_full(void) { return top == STACK_SIZE; }
+
+void push(int i) {
+  if (is_full()) {
+    terminate("error in push: stack is full");
+  }
+
+  contents[top++] = i;
+}
+
+int pop(void) {
+  if (is_empty()) {
+    terminate("error in pop: stack is empty");
+  }
+
+  return contents[--top];
+}

--- a/src/ch-19/stack/stack2.c
+++ b/src/ch-19/stack/stack2.c
@@ -1,0 +1,58 @@
+// The implentation of `stack.h` by using a linked list.
+
+#include "stack.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+struct node {
+  int data;
+  struct node *next;
+};
+
+// NOTE:
+// Similar to `stack1.c`, `top` and `terminate` are
+// implementation details that are kept hidden from
+// other parts of the program by using `static`.
+static struct node *top = NULL;
+
+static void terminate(const char *message) {
+  printf("%s\n", message);
+  exit(EXIT_FAILURE);
+}
+
+void make_empty(void) {
+  while (!is_empty()) {
+    pop();
+  }
+}
+
+bool is_empty() { return top == NULL; }
+
+bool is_full(void) { return false; }
+
+void push(int i) {
+  struct node *new_node = malloc(sizeof(struct node));
+  if (new_node == NULL) {
+    terminate("error in push: stack is full");
+  }
+
+  new_node->data = i;
+  new_node->next = top;
+  top = new_node;
+}
+
+int pop(void) {
+  struct node *old_top;
+  int i;
+
+  if (is_empty()) {
+    terminate("error in pop: stack is empty");
+  }
+
+  old_top = top;
+  i = top->data;
+  top = top->next;
+  free(old_top);
+
+  return i;
+}


### PR DESCRIPTION
This example showcases how a C program can be modularized.

`stack.h` header file (similar to the idea of traits/interfaces in other programming languages) can be used to store the declarations that can be used by the "clients".

The files `stack1.c` and `stack2.c` correpsond to different implementations that define the functions declared in the header file.

By using the `static` keyword in implementations, we can prevent clients from accessing the implementation details and alter the functionality of a module.

So, a client can include `stack.h` and based on the linked implementation, they can use either `stack1.c` or `stack2.c`.