### PR TITLE
feat(stack-adt): Add `stackADT.c` example

### DIFF
--- a/src/ch-19/stackADT/stackADT.c
+++ b/src/ch-19/stackADT/stackADT.c
@@ -1,0 +1,53 @@
+// Implementing `stackADT.h` using a fixed-length array.
+
+#include "stackADT.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define STACK_SIZE 100
+
+// NOTE: The incomplete type in the header file
+// is fully defined in here.
+struct stack_type {
+  Item contents[STACK_SIZE];
+  int top;
+};
+
+static void terminate(const char *message) {
+  printf("%s\n", message);
+  exit(EXIT_FAILURE);
+}
+
+Stack create(void) {
+  Stack s = malloc(sizeof(struct stack_type));
+  if (s == NULL) {
+    terminate("error in create: stack could not be created");
+  }
+
+  s->top = 0;
+  return s;
+}
+
+void destroy(Stack s) { free(s); }
+
+void make_empty(Stack s) { s->top = 0; }
+
+bool is_empty(Stack s) { return s->top == 0; }
+
+bool is_full(Stack s) { return s->top == STACK_SIZE; }
+
+void push(Stack s, Item i) {
+  if (is_full(s)) {
+    terminate("error in push: stack is full");
+  }
+
+  s->contents[s->top++] = i;
+}
+
+Item pop(Stack s) {
+  if (is_empty(s)) {
+    terminate("error in pop: stack is empty");
+  }
+
+  return s->contents[--s->top];
+}

--- a/src/ch-19/stackADT/stackADT.h
+++ b/src/ch-19/stackADT/stackADT.h
@@ -1,0 +1,17 @@
+#ifndef STACKADT_H
+#define STACKADT_H
+
+#include <stdbool.h>
+
+typedef struct stack_type *Stack;
+typedef int Item;
+
+Stack create(void);
+void destroy(Stack s);
+void make_empty(Stack s);
+bool is_empty(Stack s);
+bool is_full(Stack s);
+void push(Stack s, Item i);
+Item pop(Stack s);
+
+#endif

--- a/src/ch-19/stackADT/stackADT2.c
+++ b/src/ch-19/stackADT/stackADT2.c
@@ -1,0 +1,60 @@
+// Implementing `stackADT2.h` using a dynamic array.
+
+#include "stackADT2.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+struct stack_type {
+  Item *contents;
+  int top;
+  int size;
+};
+
+static void terminate(const char *message) {
+  printf("%s\n", message);
+  exit(EXIT_FAILURE);
+}
+
+Stack create(int size) {
+  Stack s = malloc(sizeof(struct stack_type));
+  if (s == NULL) {
+    terminate("error in create: stack could not be created");
+  }
+
+  s->contents = malloc(sizeof(Item) * size);
+  if (s->contents == NULL) {
+    free(s);
+    terminate("error in create: stack could not be created");
+  }
+
+  s->top = 0;
+  s->size = size;
+  return s;
+}
+
+void destroy(Stack s) {
+  free(s->contents);
+  free(s);
+}
+
+void make_empty(Stack s) { s->top = 0; }
+
+bool is_empty(Stack s) { return s->top == 0; }
+
+bool is_full(Stack s) { return s->top == s->size; }
+
+void push(Stack s, Item i) {
+  if (is_full(s)) {
+    terminate("error in push: stack is full");
+  }
+
+  s->contents[s->top++] = i;
+}
+
+Item pop(Stack s) {
+  if (is_empty(s)) {
+    terminate("error in pop: stack is empty");
+  }
+
+  return s->contents[--s->top];
+}

--- a/src/ch-19/stackADT/stackADT2.h
+++ b/src/ch-19/stackADT/stackADT2.h
@@ -1,0 +1,25 @@
+#ifndef STACKADT_H
+#define STACKADT_H
+
+#include <stdbool.h>
+
+typedef struct stack_type *Stack;
+typedef int Item;
+
+// NOTE:
+// Now that we want to use a dynamically
+// allocated array for our stack, we need
+// the initial size from the clients.
+// By doing so, we avoid allocating too much
+// or less, we just allocate the exact amount
+// that clients want.
+Stack create(int size);
+
+void destroy(Stack s);
+void make_empty(Stack s);
+bool is_empty(Stack s);
+bool is_full(Stack s);
+void push(Stack s, Item i);
+Item pop(Stack s);
+
+#endif

--- a/src/ch-19/stackADT/stackADT3.c
+++ b/src/ch-19/stackADT/stackADT3.c
@@ -1,0 +1,69 @@
+// Implementing `stackADT.h` using a linked-list.
+
+#include "stackADT.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+struct node {
+  Item data;
+  struct node *next;
+};
+
+struct stack_type {
+  struct node *top;
+};
+
+static void terminate(const char *message) {
+  printf("%s\n", message);
+  exit(EXIT_FAILURE);
+}
+
+Stack create(void) {
+  Stack s = malloc(sizeof(struct stack_type));
+  if (s == NULL) {
+    terminate("error in create: stack could not be created");
+  }
+
+  s->top = NULL;
+  return s;
+}
+
+void destroy(Stack s) {
+  make_empty(s);
+  free(s);
+}
+
+void make_empty(Stack s) {
+  while (!is_empty(s)) {
+    pop(s);
+  }
+}
+
+bool is_empty(Stack s) { return s->top == NULL; }
+
+bool is_full(Stack s) { return false; }
+
+void push(Stack s, Item i) {
+  struct node *n = malloc(sizeof(struct node));
+  if (n == NULL) {
+    terminate("error in push: stack is full");
+  }
+
+  n->data = i;
+  n->next = s->top;
+  s->top = n;
+}
+
+Item pop(Stack s) {
+  if (is_empty(s)) {
+    terminate("error in pop: stack is empty");
+  }
+
+  struct node *old_top = s->top;
+  Item i = old_top->data;
+
+  s->top = old_top->next;
+  free(old_top);
+
+  return i;
+}

--- a/src/ch-19/stackADT/stackclient.c
+++ b/src/ch-19/stackADT/stackclient.c
@@ -1,0 +1,40 @@
+#include "stackADT.h"
+#include <stdio.h>
+
+int main(void) {
+  Stack s1, s2;
+  int n;
+
+  s1 = create();
+  s2 = create();
+
+  push(s1, 1);
+  push(s1, 2);
+
+  n = pop(s1);
+  printf("popped %d from s1\n", n);
+  push(s2, n);
+
+  n = pop(s1);
+  printf("popped %d from s1\n", n);
+  push(s2, n);
+
+  destroy(s1);
+
+  while (!is_empty(s2)) {
+    printf("popped %d from s2\n", pop(s2));
+  }
+
+  push(s2, 3);
+  make_empty(s2);
+
+  if (is_empty(s2)) {
+    printf("s2 is empty\n");
+  } else {
+    printf("s2 is not empty\n");
+  }
+
+  destroy(s2);
+
+  return 0;
+}


### PR DESCRIPTION
This example showcases the usage of incomplete types in C, which is the only way (so far) we have to create abstractions around types.

In this example, an abstract data type is created for a stack data structure, and its fields are kept hidden from the client.

The example utilizes this abstract data type (ADT) and shows three different implementations of a stack:

- Via a fixed size array.
- Via a dynamic size array.
- Via a linked list.