### PR TITLE
feat(xor): Add `xor.c` example

### DIFF
--- a/src/ch-20/xor/msg.txt
+++ b/src/ch-20/xor/msg.txt
@@ -1,0 +1,3 @@
+Trust not him with your secrets, who, when left
+alone in your room, turns over your papers.
+			--Johann Kaspar Lavater (1741-1801)

--- a/src/ch-20/xor/xor.c
+++ b/src/ch-20/xor/xor.c
@@ -1,0 +1,20 @@
+// Performs XOR encryption.
+
+#include <ctype.h>
+#include <stdio.h>
+#define KEY '&'
+
+int main(void) {
+  int orig_char, new_char;
+
+  while ((orig_char = getchar()) != EOF) {
+    new_char = orig_char ^ KEY;
+    if (isprint(orig_char) && isprint(new_char)) {
+      putchar(new_char);
+    } else {
+      putchar(orig_char);
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The author showcases a basic bit manipulation by using XOR to encrypt a given text.

Some of the characters in the text become invisible control characters after XORing them with our private key. For now, they are left untouched.

To encrypt and decrypt the text, see the commands below:

```bash
xor < msg.txt > newmsg.txt #encrypt
xor < newmsg.txt #decrypt
```