### PR TITLE
feat(invclear): Add `invclear.c` example

### DIFF
--- a/src/ch-22/invclear/Makefile
+++ b/src/ch-22/invclear/Makefile
@@ -1,0 +1,8 @@
+invclear: invclear.o inv.o
+	gcc -o ./invclear invclear.o inv.o
+
+invclear.o: invclear.c inv.h
+	gcc -c invclear.c inv.h
+
+inv.o: inv.c inv.h
+	gcc -c inv.c inv.h

--- a/src/ch-22/invclear/inv.c
+++ b/src/ch-22/invclear/inv.c
@@ -1,0 +1,48 @@
+#include "inv.h"
+#include <stdio.h>
+
+enum error_kind {
+  EINVLEN = -1,
+  EINVOP = -2,
+  EINVWR = -3,
+};
+
+int generate_inv(const char *name, int len) {
+  if (len > MAX_PARTS) {
+    fprintf(stderr, "cannot generate inventory: len %d exceeds the limit %d",
+            len, MAX_PARTS);
+    return EINVLEN;
+  }
+
+  FILE *fp;
+  if ((fp = fopen(name, "wb")) == NULL) {
+    return EINVOP;
+  }
+
+  struct part inventory[len];
+  for (int i = 0; i < len; i++) {
+    sprintf(inventory[i].name, "part-%d", i);
+    inventory[i].number = i;
+    // NOTE: This field is alternated between 0 and 1 to see the changes done by
+    // the original example in the book.
+    // We can diff the binary files to see the different bytes:
+    // ```bash
+    // cmp -l ./inventory.dat ./inventory2.dat
+    // ```
+    inventory[i].on_hand = i % 2;
+  }
+
+  int w_len = fwrite(inventory, sizeof(struct part), len, fp);
+  fclose(fp);
+
+  if (w_len != len) {
+    remove(name);
+    fprintf(stderr,
+            "cannot generate inventory: partial write occurred: failed to "
+            "write %d part(s) out of %d parts",
+            len - w_len, len);
+    return EINVWR;
+  }
+
+  return 0;
+}

--- a/src/ch-22/invclear/inv.h
+++ b/src/ch-22/invclear/inv.h
@@ -1,0 +1,17 @@
+#ifndef INV_H
+#define INV_H
+
+#include <stdio.h>
+
+#define NAME_LEN 25
+#define MAX_PARTS 100
+
+struct part {
+  int number;
+  char name[NAME_LEN + 1];
+  int on_hand;
+};
+
+int generate_inv(const char *name, int len);
+
+#endif

--- a/src/ch-22/invclear/invclear.c
+++ b/src/ch-22/invclear/invclear.c
@@ -1,0 +1,38 @@
+// Modifies a file of part records by setting the quantity on hand to zero for
+// all records.
+
+#include "inv.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+  // NOTE: In the book, the file `inventory.dat` is not shown
+  // or provided in any way.
+  //
+  // Therefore, I updated the example a little bit to generate
+  // two inventories, the first one is the original, the second
+  // is the one that this example uses.
+  generate_inv("inventory.dat", MAX_PARTS);
+  generate_inv("inventory2.dat", MAX_PARTS);
+
+  FILE *fp;
+  if ((fp = fopen("inventory2.dat", "rb+")) == NULL) {
+    fprintf(stderr, "can't open inventory file\n");
+    exit(EXIT_FAILURE);
+  }
+
+  struct part inventory[MAX_PARTS];
+  int num_parts = fread(inventory, sizeof(struct part), MAX_PARTS, fp);
+  for (int i = 0; i < num_parts; i++) {
+    inventory[i].on_hand = 0;
+  }
+
+  // NOTE: `rewind` needs to be called to set the file position
+  // back to the beginning of the file to overwrite the previous contents.
+  // If we don't use `rewind`, we append the changes instead.
+  rewind(fp);
+  fwrite(inventory, sizeof(struct part), num_parts, fp);
+  fclose(fp);
+
+  return 0;
+}


### PR DESCRIPTION
The author showcases the usage of block I/O and file positioning in this example by reading from/writing to a binary file.

The binary file in the example is basically a memory block of an `inventory`, which is an array of `part` structs.

Since the original binary file is not provided in the example, I modified it a little bit to make it generate 2 binary files.

This makes it a bit easier to understand how we modify the file via `fwrite` and `rewind`.